### PR TITLE
Configuration for Poison Skeletons

### DIFF
--- a/src/main/java/toast/specialMobs/EnchantmentSpecial.java
+++ b/src/main/java/toast/specialMobs/EnchantmentSpecial.java
@@ -21,7 +21,7 @@ public class EnchantmentSpecial extends Enchantment
         plagueSword = id < 0 ? null : new EnchantmentSpecial(id, "plagueSword", 3, EnumEnchantmentType.weapon);
 
         id = Properties.getInt(Properties.ENCHANTS, "poison_bow");
-        poisonBow = id < 0 ? null : new EnchantmentSpecial(id, "poisonBow", 2, EnumEnchantmentType.bow);
+        poisonBow = id < 0 ? null : new EnchantmentSpecial(id, "poisonBow", Properties.getInt(Properties.ENCHANTS, "poison_lvl", EnumEnchantmentType.bow);
         id = Properties.getInt(Properties.ENCHANTS, "poison_sword");
         poisonSword = id < 0 ? null : new EnchantmentSpecial(id, "poisonSword", 1, EnumEnchantmentType.weapon);
     }

--- a/src/main/java/toast/specialMobs/Properties.java
+++ b/src/main/java/toast/specialMobs/Properties.java
@@ -125,6 +125,7 @@ public abstract class Properties {
         Properties.add(config, Properties.ENCHANTS, "plague_sword", 163);
         Properties.add(config, Properties.ENCHANTS, "poison_bow", 164);
         Properties.add(config, Properties.ENCHANTS, "poison_sword", 165);
+        Properties.add(config, Properties.ENCHANTS, "poison_lvl", 2, "The level of poison inflicted by poison skeletons (min 1).");
 
         Properties.add(config, Properties.SPAWNING, "end_ender_creeper", 1, 0, Integer.MAX_VALUE);
         Properties.add(config, Properties.SPAWNING, "nether_fire_creeper", 10, 0, Integer.MAX_VALUE);


### PR DESCRIPTION
Allow configuration of poison level inflicted by Poison Skeleton (Defaults to 2).

Being hit by one is a guaranteed death without milk. 
While it adds to the challenge to the user experience, it can very well make it or break it for many.
This gives the user a way to tune it to their preference.