### PR TITLE
Message discriminators *MUST* exist on the channel on both sides if t…

### DIFF
--- a/src/main/java/toast/specialMobs/CommonProxy.java
+++ b/src/main/java/toast/specialMobs/CommonProxy.java
@@ -1,9 +1,15 @@
 package toast.specialMobs;
 
+import net.minecraft.world.World;
+
 public class CommonProxy {
 
     // Registers render files if this is the client side.
     public void registerRenderers() {
         // Client method.
+    }
+
+    public World getClientWorld() {
+        return null;
     }
 }

--- a/src/main/java/toast/specialMobs/_SpecialMobs.java
+++ b/src/main/java/toast/specialMobs/_SpecialMobs.java
@@ -386,11 +386,8 @@ public class _SpecialMobs {
 
         int id = 0;
         _SpecialMobs.CHANNEL = NetworkRegistry.INSTANCE.newSimpleChannel("SM|EX");
-        if (event.getSide() == Side.CLIENT) {
-            _SpecialMobs.CHANNEL
-                    .registerMessage(MessageExplosion.Handler.class, MessageExplosion.class, id++, Side.CLIENT);
-            _SpecialMobs.CHANNEL.registerMessage(MessageTexture.Handler.class, MessageTexture.class, id++, Side.CLIENT);
-        }
+        _SpecialMobs.CHANNEL.registerMessage(MessageExplosion.Handler.class, MessageExplosion.class, id++, Side.CLIENT);
+        _SpecialMobs.CHANNEL.registerMessage(MessageTexture.Handler.class, MessageTexture.class, id++, Side.CLIENT);
     }
 
     /**

--- a/src/main/java/toast/specialMobs/client/ClientProxy.java
+++ b/src/main/java/toast/specialMobs/client/ClientProxy.java
@@ -1,7 +1,9 @@
 package toast.specialMobs.client;
 
+import cpw.mods.fml.client.FMLClientHandler;
 import net.minecraft.client.renderer.RenderBlocks;
 
+import net.minecraft.world.World;
 import toast.specialMobs.CommonProxy;
 import toast.specialMobs.entity.EntityLavaMonster;
 import toast.specialMobs.entity.EntitySpecialFishHook;
@@ -47,5 +49,9 @@ public class ClientProxy extends CommonProxy {
         RenderingRegistry.registerEntityRenderingHandler(EntitySpecialFishHook.class, new RenderSpecialFishHook());
         RenderingRegistry.registerEntityRenderingHandler(EntitySpecialSpitball.class, new RenderSpecialSpitball());
         RenderingRegistry.registerEntityRenderingHandler(EntityLavaMonster.class, new RenderLavaMonster());
+    }
+
+    public World getClientWorld() {
+        return FMLClientHandler.instance().getWorldClient();
     }
 }

--- a/src/main/java/toast/specialMobs/network/MessageExplosion.java
+++ b/src/main/java/toast/specialMobs/network/MessageExplosion.java
@@ -6,11 +6,11 @@ import net.minecraft.world.ChunkPosition;
 import net.minecraft.world.Explosion;
 import net.minecraft.world.World;
 
-import cpw.mods.fml.client.FMLClientHandler;
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
 import cpw.mods.fml.common.network.simpleimpl.MessageContext;
 import io.netty.buffer.ByteBuf;
+import toast.specialMobs._SpecialMobs;
 
 public class MessageExplosion implements IMessage {
 
@@ -161,7 +161,8 @@ public class MessageExplosion implements IMessage {
         @Override
         public IMessage onMessage(MessageExplosion message, MessageContext ctx) {
             try {
-                World world = FMLClientHandler.instance().getWorldClient();
+                World world = _SpecialMobs.proxy.getClientWorld();
+                if(world==null) return null;
                 if (message.type == ExplosionType.LIGHTNING) {
                     if (message.size < 0.0F) {
                         message.size = 0.0F;

--- a/src/main/java/toast/specialMobs/network/MessageTexture.java
+++ b/src/main/java/toast/specialMobs/network/MessageTexture.java
@@ -7,7 +7,6 @@ import net.minecraft.world.World;
 import toast.specialMobs._SpecialMobs;
 import toast.specialMobs.entity.ISpecialMob;
 import toast.specialMobs.entity.SpecialMobData;
-import cpw.mods.fml.client.FMLClientHandler;
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
 import cpw.mods.fml.common.network.simpleimpl.MessageContext;
@@ -74,7 +73,8 @@ public class MessageTexture implements IMessage {
         @Override
         public IMessage onMessage(MessageTexture message, MessageContext ctx) {
             try {
-                World world = FMLClientHandler.instance().getWorldClient();
+                World world = _SpecialMobs.proxy.getClientWorld();
+                if(world == null) return null;
                 ISpecialMob mob = (ISpecialMob) world.getEntityByID(message.entityId);
                 if (mob != null) {
                     SpecialMobData data = mob.getSpecialData();


### PR DESCRIPTION
Message discriminators *MUST* exist on the channel on both sides if there is more than one message or the one message does not use ID 0, and this mod has two messages, meaning when a MessageTexture gets sent from the server then it gets a discriminant of 0, meaning the client then deserializes it as MessageExplosion, which "most" of the time it will just harmless tell the client explosions are happening randomly around the world where they are not, but sometimes it crashes due to not enough data in the packet stream to deserialize, registering the messages on both server and client fixes it.