### PR TITLE
fix: fishing zombie throwing rod while dead

### DIFF
--- a/src/main/java/toast/specialMobs/entity/pigzombie/EntityFishingPigZombie.java
+++ b/src/main/java/toast/specialMobs/entity/pigzombie/EntityFishingPigZombie.java
@@ -95,6 +95,7 @@ public class EntityFishingPigZombie extends Entity_SpecialPigZombie implements I
     /// Called each tick this entity's attack target can be seen.
     @Override
     protected void attackEntity(Entity target, float distance) {
+        // TODO: Remove code duplication between EntityFishingZombie, EntityFishingPigZombie, EntityFishingSilverfish
         super.attackEntity(target, distance);
         if (!this.worldObj.isRemote && this.rodTime <= 0 && this.getFishingRod()) {
             if (distance > 3.0F && distance < 10.0F) {

--- a/src/main/java/toast/specialMobs/entity/silverfish/EntityFishingSilverfish.java
+++ b/src/main/java/toast/specialMobs/entity/silverfish/EntityFishingSilverfish.java
@@ -57,6 +57,7 @@ public class EntityFishingSilverfish extends Entity_SpecialSilverfish implements
     /// Called each tick this entity's attack target can be seen.
     @Override
     protected void attackEntity(Entity target, float distance) {
+        // TODO: Remove code duplication between EntityFishingZombie, EntityFishingPigZombie, EntityFishingSilverfish
         super.attackEntity(target, distance);
         if (!this.worldObj.isRemote && this.rodTime <= 0) {
             if (distance > 3.0F && distance < 10.0F) {

--- a/src/main/java/toast/specialMobs/entity/zombie/EntityFishingZombie.java
+++ b/src/main/java/toast/specialMobs/entity/zombie/EntityFishingZombie.java
@@ -88,10 +88,13 @@ public class EntityFishingZombie extends Entity_SpecialZombie implements IAngler
     /// Called every tick while this entity is alive.
     @Override
     public void onLivingUpdate() {
+        // TODO: Remove code duplication between EntityFishingZombie, EntityFishingPigZombie, EntityFishingSilverfish
+        // EntityFishingZombie is implemented via onLivingUpdate instead of attackEntity because Zombies use the new
+        // Mob AI. Could the fishing behavior be migrated to a Task in the new Mob AI system?
         if (this.rodTime > 0) {
             this.rodTime--;
         }
-        if (!this.worldObj.isRemote && this.rodTime <= 0 && this.getFishingRod()) {
+        if (!this.worldObj.isRemote && this.rodTime <= 0 && this.getFishingRod() && !this.isMovementBlocked()) {
             Entity target = this.getAttackTarget();
             if (target != null) {
                 float distanceSq = (float) this.getDistanceSqToEntity(target);


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17058

EntityFishingZombie uses a different implementation (using `onLivingUpdate`) for the fishing hook logic than EntityFishingPigZombie and EntityFishingSilverfish.
This is necessary because the base Zombie uses the modern AI Task System, where `attackEntity` isn't used anymore.
An oversight was made however: `attackEntity` doesn't get called if the Entity is dead, but `onLivingUpdate` does.
This causes Fishing Zombies to be able to throw Fishing Rods while dead (in the Dying animation before the entity is deleted).

https://github.com/user-attachments/assets/cd8839bd-5f2a-47a7-8a36-ffae087805bf

(Note the fishing rod bobber being being thrown after the Zombie is killed. This can still hit and pull players)
![image](https://github.com/user-attachments/assets/e3be4628-7e1c-4b36-8eb5-048971af5ac4)

Just adding a check with `isMovementBlocked` fixes this (using this function instead of isDead seems to be convention for stopping Mob AI).