### PR TITLE
Fix special endermen dropping their held block if not killed.

### DIFF
--- a/src/main/java/toast/specialMobs/entity/enderman/Entity_SpecialEnderman.java
+++ b/src/main/java/toast/specialMobs/entity/enderman/Entity_SpecialEnderman.java
@@ -104,7 +104,7 @@ public class Entity_SpecialEnderman extends EntityEnderman implements ISpecialMo
     /// Called to remove this entity from the world.
     @Override
     public void setDead() {
-        if (!this.worldObj.isRemote) {
+        if (!this.worldObj.isRemote && this.getHealth() <= 0.0f) {
             Block carried = this.func_146080_bZ();
             if (carried != null) {
                 carried.dropBlockAsItem(


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17828.

Details: Capturing a mob in a soul vial calls the `setDead()` method on the entity being captured, which handles cleanup of various data associated with the entity. However, some mods add other functionality to this method, which can be repeatedly triggered by capturing and releasing the same mob in a soul vial.

The vanilla way to prevent this (for example, to stop a large slime from splitting into smaller slimes when removed in this way) is to check whether the entity's health is zero when this method is called. This means that these effects only trigger when the entity actually dies, and not when it is removed from game by other means. I have fixed this for endermen here, and for two other mobs elsewhere:

Heatscar Spider (Natura): https://github.com/GTNewHorizons/Natura/pull/26

MedSlime (Thaumic Horizons): https://github.com/GTNewHorizons/ThaumicHorizons/pull/78

These are the only three cases I could find by an org-wide search that could cause issues if triggered repeatedly, and do not already contain the check for entity health.