### PR TITLE
Prevent Witch Spider infinite projectile duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # SpecialMobs
 Adds variants to the vanilla mobs to make them more interesting and challenging.
 
-Changelog is located at src/main/resources/changelog.txt
+Legacy changelog is located at src/main/resources/changelog.txt
 
-# Fork
-This mod was forked by the GT:NH Team to continue the development of the 1.7.10 Branch.
-The up-to-date Master branch can be found on our Jenkins:
-http://jenkins.usrv.de
+## Fork
+This mod was forked by the GTNH Team to continue the development of the 1.7.10 branch.

--- a/src/main/java/toast/specialMobs/entity/spider/EntityWitchSpider.java
+++ b/src/main/java/toast/specialMobs/entity/spider/EntityWitchSpider.java
@@ -18,6 +18,8 @@ import toast.specialMobs._SpecialMobs;
 
 public class EntityWitchSpider extends Entity_SpecialSpider {
 
+    private static final String TAG_DEFLECTED_PROJECTILE = "witchSpiderDeflected";
+
     public static final ResourceLocation[] TEXTURES = new ResourceLocation[] {
             new ResourceLocation(_SpecialMobs.TEXTURE_PATH + "spider/witch.png"),
             new ResourceLocation(_SpecialMobs.TEXTURE_PATH + "spider/witch_eyes.png") };
@@ -84,6 +86,10 @@ public class EntityWitchSpider extends Entity_SpecialSpider {
     public boolean attackEntityFrom(DamageSource damageSource, float damage) {
         Entity entity = damageSource.getSourceOfDamage();
         if (damageSource.isProjectile() && entity != null) {
+            NBTTagCompound data = entity.getEntityData();
+            if (data == null || data.hasKey(TAG_DEFLECTED_PROJECTILE) && data.getBoolean(TAG_DEFLECTED_PROJECTILE)) {
+                return super.attackEntityFrom(damageSource, damage);
+            }
             Entity deflected = null;
             String entityName = EntityList.getEntityString(entity);
             if (entityName != null) {
@@ -93,6 +99,12 @@ public class EntityWitchSpider extends Entity_SpecialSpider {
                 NBTTagCompound tag = new NBTTagCompound();
                 entity.writeToNBT(tag);
                 deflected.readFromNBT(tag);
+
+                NBTTagCompound deflectedData = deflected.getEntityData();
+                if (deflectedData == null) {
+                    return super.attackEntityFrom(damageSource, damage);
+                }
+                deflectedData.setBoolean(TAG_DEFLECTED_PROJECTILE, true);
 
                 if (entity instanceof EntityArrow) {
                     ((EntityArrow) deflected).shootingEntity = this;


### PR DESCRIPTION
The Witch Spider can deflect projectiles. When hit with an AoE attack like the Draconic Bow's Shockwave, it will deflect the arrow. The deflected arrow will explode in the vicinity, attacking the spider again, causing another deflected arrow to spawn and creating a loop. This PR adds a marker to the deflected projectiles so that they are only deflected once.

fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16062