### PR TITLE
Prevent ender creepers from teleporting to non-normal cubes (Including railcraft tank blocks) 

### DIFF
--- a/src/main/java/toast/specialMobs/entity/creeper/EntityEnderCreeper.java
+++ b/src/main/java/toast/specialMobs/entity/creeper/EntityEnderCreeper.java
@@ -237,7 +237,7 @@ public class EntityEnderCreeper extends Entity_SpecialCreeper {
             boolean canTeleportToBlock = false;
             while (!canTeleportToBlock && blockY > 0) {
                 block = this.worldObj.getBlock(blockX, blockY - 1, blockZ);
-                if (block != null && block.getMaterial().blocksMovement()) {
+                if (block != null && block.getMaterial().blocksMovement() && block.isNormalCube()) {
                     canTeleportToBlock = true;
                 } else {
                     --this.posY;


### PR DESCRIPTION
This PR prevents ender creepers from teleporting to any block that is a non-normal (solid, opaque) cube, which will include railcraft tank blocks as they are able to provide power and therefore are not normal cubes. 

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/22925.